### PR TITLE
Added Dockerfile and how to use Dockerfile in README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+# author: Sam Edwardes
+# date: 2020-02-04
+# attribution:
+#   https://github.com/ttimbers/makefile2graph/blob/master/Dockerfile
+#   https://github.com/ttimbers/data_analysis_pipeline_eg/blob/master/Dockerfile
+
+# BUILD:
+#   docker build --tag dsci-522-ufc .
+# RUN CONTAINER BASIC:
+#   docker run -it --rm dsci-522-ufc bin/bash
+# RUN CONTAINTER WITH VOLUMES:
+#   docker run -it --rm -v /Users/samedwardes/UBC/block-04/522-workflows/DSCI522_group315:/root/ufc dsci-522-ufc bin/bash
+
+FROM rocker/tidyverse
+
+#############################
+# R tidyverse
+#############################
+
+# Install additional R packages
+RUN Rscript -e "install.packages('caret')"
+RUN Rscript -e "install.packages('docopt')"
+RUN Rscript -e "install.packages('GGally')"
+RUN Rscript -e "install.packages('janitor')"
+
+
+#############################
+# Python
+#############################
+
+# install the anaconda distribution of python
+# RUN wget --quiet https://repo.anaconda.com/archive/Anaconda3-2019.10-Linux-x86_64.sh -O ~/anaconda.sh && \
+#     /bin/bash ~/anaconda.sh -b -p /opt/conda && \
+#     rm ~/anaconda.sh && \
+#     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+#     echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+#     echo "conda activate base" >> ~/.bashrc && \
+#     find /opt/conda/ -follow -type f -name '*.a' -delete && \
+#     find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
+#     /opt/conda/bin/conda clean -afy && \
+#     /opt/conda/bin/conda update -n base -c defaults conda
+
+# install docopt python package
+# RUN /opt/conda/bin/conda install -y -c anaconda docopt
+
+# put anaconda python in path
+# ENV PATH="/opt/conda/bin:${PATH}"
+
+#############################
+# makefile2graph
+#############################
+# get OS updates and install build tools
+# RUN apt-get install -y build-essential
+# install graphviz
+# RUN apt-get install -y graphviz

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,17 @@
 
 # BUILD:
 #   docker build --tag dsci-522-ufc .
-# RUN CONTAINER BASIC:
+# RUN CONTAINER AND OPEN BASH:
 #   docker run -it --rm dsci-522-ufc bin/bash
-# RUN CONTAINTER WITH VOLUMES:
-#   docker run -it --rm -v /Users/samedwardes/UBC/block-04/522-workflows/DSCI522_group315:/root/ufc dsci-522-ufc bin/bash
+# RUN CONTAINTER, OPEN BASH AND ATTACH WORKING DIRECTORY:
+#   docker run -it --rm -v $(pwd):/root/ufc dsci-522-ufc bin/bash
+# RUN UFC ANALYSIS
+#   docker run -it --rm -v $(pwd):/root/ufc dsci-522-ufc cd root/ufc make all
 
 FROM rocker/tidyverse
 
 #############################
-# R tidyverse
+# R
 #############################
 
 # Install additional R packages
@@ -22,6 +24,8 @@ RUN Rscript -e "install.packages('caret')"
 RUN Rscript -e "install.packages('docopt')"
 RUN Rscript -e "install.packages('GGally')"
 RUN Rscript -e "install.packages('janitor')"
+RUN Rscript -e "install.packages('kableExtra')"
+RUN Rscript -e "install.packages('tidyselect')"
 
 
 #############################
@@ -29,22 +33,34 @@ RUN Rscript -e "install.packages('janitor')"
 #############################
 
 # install the anaconda distribution of python
-# RUN wget --quiet https://repo.anaconda.com/archive/Anaconda3-2019.10-Linux-x86_64.sh -O ~/anaconda.sh && \
-#     /bin/bash ~/anaconda.sh -b -p /opt/conda && \
-#     rm ~/anaconda.sh && \
-#     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-#     echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
-#     echo "conda activate base" >> ~/.bashrc && \
-#     find /opt/conda/ -follow -type f -name '*.a' -delete && \
-#     find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
-#     /opt/conda/bin/conda clean -afy && \
-#     /opt/conda/bin/conda update -n base -c defaults conda
+RUN wget --quiet https://repo.anaconda.com/archive/Anaconda3-2019.10-Linux-x86_64.sh -O ~/anaconda.sh && \
+    /bin/bash ~/anaconda.sh -b -p /opt/conda && \
+    rm ~/anaconda.sh && \
+    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    echo "conda activate base" >> ~/.bashrc && \
+    find /opt/conda/ -follow -type f -name '*.a' -delete && \
+    find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
+    /opt/conda/bin/conda clean -afy && \
+    /opt/conda/bin/conda update -n base -c defaults conda
 
 # install docopt python package
-# RUN /opt/conda/bin/conda install -y -c anaconda docopt
+RUN /opt/conda/bin/conda install -y -c anaconda docopt
+RUN /opt/conda/bin/conda update -y --all
+
+# altair
+# https://github.com/UBC-MDS/docker-stack-altair/blob/master/Dockerfile
+RUN apt-get update && apt install -y chromium && apt-get install -y libnss3 && apt-get install unzip
+# Install chromedriver
+RUN wget -q "https://chromedriver.storage.googleapis.com/79.0.3945.36/chromedriver_linux64.zip" -O /tmp/chromedriver.zip \
+    && unzip /tmp/chromedriver.zip -d /usr/bin/ \
+    && rm /tmp/chromedriver.zip && chown root:root /usr/bin/chromedriver && chmod +x /usr/bin/chromedriver
+RUN /opt/conda/bin/conda install -y -c conda-forge altair 
+RUN /opt/conda/bin/conda install -y vega_datasets 
+RUN /opt/conda/bin/conda install -y selenium
 
 # put anaconda python in path
-# ENV PATH="/opt/conda/bin:${PATH}"
+ENV PATH="/opt/conda/bin:${PATH}"
 
 #############################
 # makefile2graph

--- a/README.Rmd
+++ b/README.Rmd
@@ -36,6 +36,21 @@ The final report can be found:
 
 ## Usage
 
+**1. Using Docker**
+
+*note - the instructions in this section also depends on running this in a unix shell (e.g., terminal or Git Bash), if you are using Windows Command Prompt, replace /$(pwd) with PATH_ON_YOUR_COMPUTER.*
+
+1. Install [Docker](https://www.docker.com/get-started)
+2. Download/clone this repository
+3. Use the command line to navigate to the root of this downloaded/cloned repo
+4. Type the following:
+
+```
+docker run -it --rm -v $(pwd):/root/ufc dsci-522-ufc cd root/ufc make all
+```
+
+**2. After installing all dependencies (does not depend on Docker)**
+
 To replicate the analysis, you can clone this GitHub repository and install the [dependencies](#dependencies). Then you can run the following command in the terminal from the root directory of this project:
 
 ```
@@ -62,14 +77,17 @@ make clean
 - chromedriver-binary==80.0.3987.16.0
 
 Note: Users may have an issue producing altair plots. You may need to download the latest version of ChromeDriver.Instructions for installing chromeDriver:
-  ```
-  conda install selenium
-  conda install -c conda-forge python-chromedriver-binary
-  ```
-  You need to include the ChromeDriver location in your system PATH. Please follow the instructions [here](https://www.kenst.com/2015/03/including-the-chromedriver-location-in-macos-system-path/) for mac users and [here](https://www.google.com/search?q=Including+the+ChromeDriver+location+in+PC&oq=Including+the+ChromeDriver+location+in+PC&aqs=chrome..69i57j69i60l2.2395j0j7&sourceid=chrome&ie=UTF-8) for PC users.
+
+```
+conda install selenium
+conda install -c conda-forge python-chromedriver-binary
+```
+
+You need to include the ChromeDriver location in your system PATH. Please follow the instructions [here](https://www.kenst.com/2015/03/including-the-chromedriver-location-in-macos-system-path/) for mac users and [here](https://www.google.com/search?q=Including+the+ChromeDriver+location+in+PC&oq=Including+the+ChromeDriver+location+in+PC&aqs=chrome..69i57j69i60l2.2395j0j7&sourceid=chrome&ie=UTF-8) for PC users.
   
   
 - R version 3.6.1 and R packages:
+  - caret==6.0-85
   - docopt==0.6.1
   - tidyverse==1.3.0
   - janitor==1.2.0

--- a/README.Rmd
+++ b/README.Rmd
@@ -46,10 +46,6 @@ The final report can be found:
 4. Type the following:
 
 ```
-docker build --tag dsci-522-ufc . 
-```
-
-```
 docker run -it --rm -v $(pwd):/root/ufc dsci-522-ufc cd root/ufc make all
 ```
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -46,6 +46,10 @@ The final report can be found:
 4. Type the following:
 
 ```
+docker build --tag dsci-522-ufc . 
+```
+
+```
 docker run -it --rm -v $(pwd):/root/ufc dsci-522-ufc cd root/ufc make all
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Command Prompt, replace /$(pwd) with PATH\_ON\_YOUR\_COMPUTER.*
 
 <!-- end list -->
 
+    docker build --tag dsci-522-ufc . 
+
     docker run -it --rm -v $(pwd):/root/ufc dsci-522-ufc cd root/ufc make all
 
 **2. After installing all dependencies (does not depend on Docker)**

--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ The final report can be found:
 
 ## Usage
 
+**1. Using Docker**
+
+*note - the instructions in this section also depends on running this in
+a unix shell (e.g., terminal or Git Bash), if you are using Windows
+Command Prompt, replace /$(pwd) with PATH\_ON\_YOUR\_COMPUTER.*
+
+1.  Install [Docker](https://www.docker.com/get-started)
+2.  Download/clone this repository
+3.  Use the command line to navigate to the root of this
+    downloaded/cloned repo
+4.  Type the
+    following:
+
+<!-- end list -->
+
+    docker run -it --rm -v $(pwd):/root/ufc dsci-522-ufc cd root/ufc make all
+
+**2. After installing all dependencies (does not depend on Docker)**
+
 To replicate the analysis, you can clone this GitHub repository and
 install the [dependencies](#dependencies). Then you can run the
 following command in the terminal from the root directory of this
@@ -78,15 +97,20 @@ this project:
 
 Note: Users may have an issue producing altair plots. You may need to
 download the latest version of ChromeDriver.Instructions for installing
-chromeDriver: `conda install selenium conda install -c conda-forge
-python-chromedriver-binary` You need to include the ChromeDriver
-location in your system PATH. Please follow the instructions
+chromeDriver:
+
+    conda install selenium
+    conda install -c conda-forge python-chromedriver-binary
+
+You need to include the ChromeDriver location in your system PATH.
+Please follow the instructions
 [here](https://www.kenst.com/2015/03/including-the-chromedriver-location-in-macos-system-path/)
 for mac users and
 [here](https://www.google.com/search?q=Including+the+ChromeDriver+location+in+PC&oq=Including+the+ChromeDriver+location+in+PC&aqs=chrome..69i57j69i60l2.2395j0j7&sourceid=chrome&ie=UTF-8)
 for PC users.
 
   - R version 3.6.1 and R packages:
+      - caret==6.0-85
       - docopt==0.6.1
       - tidyverse==1.3.0
       - janitor==1.2.0

--- a/README.md
+++ b/README.md
@@ -65,8 +65,6 @@ Command Prompt, replace /$(pwd) with PATH\_ON\_YOUR\_COMPUTER.*
 
 <!-- end list -->
 
-    docker build --tag dsci-522-ufc . 
-
     docker run -it --rm -v $(pwd):/root/ufc dsci-522-ufc cd root/ufc make all
 
 **2. After installing all dependencies (does not depend on Docker)**

--- a/src/01_download_data.R
+++ b/src/01_download_data.R
@@ -14,7 +14,6 @@ Example: Rscript src/01_download_data.R --url=https://github.com/SamEdwardes/ufc
 " -> doc
 
 library(docopt)
-library(RCurl)
 library(testthat)
 library(stringr)
 


### PR DESCRIPTION
Added Dockerfile and how to use Dockerfile in README. Note that the docker image is a little bit large at 6.56GB. This is because we are using R, python, and Altair. We probably could make the file smaller by starting with a smaller base image... but I tried a more basic version of R for base image and ran into problems. So I suggest we stick with this.

Please let me know if you are able to reproduce on your machines!

`docker build --tag dsci-522-ufc .`

`docker run -it --rm -v $(pwd):/root/ufc dsci-522-ufc cd root/ufc make all`